### PR TITLE
Removed `if cols_with_no_width` condition from `tables.py`.

### DIFF
--- a/xhtml2pdf/tables.py
+++ b/xhtml2pdf/tables.py
@@ -183,17 +183,6 @@ class pisaTagTABLE(pisaTag):
         for i, row in enumerate(data):
             data[i] += [''] * (maxcols - len(row))
 
-        cols_with_no_width = [
-            tup for tup in enumerate(tdata.colw) if tup[1] is None or tup[1] == 0.0]
-
-        if cols_with_no_width:  # any col width not defined
-            log.debug(list(enumerate(tdata.colw)))
-            fair_division = str(100 / float(len(cols_with_no_width))) + '%'
-            log.debug("Fair division: {}".format(fair_division))
-            for i, _ in cols_with_no_width:
-                log.debug("Setting {} to {}".format(i, fair_division))
-                tdata.colw[i] = fair_division
-
         log.debug("Col widths: {}".format(list(tdata.colw)))
         if tdata.data:
             # log.debug("Table styles %r", tdata.styles)


### PR DESCRIPTION
Resolves https://github.com/xhtml2pdf/xhtml2pdf/issues/416